### PR TITLE
Fixed no_std for newest nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic-array-plus"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["debris <marek.kotewicz@gmail.com>", "Wei Tang <hi@that.world>"]
 license = "MIT"
 description = "Elastic vector backed by fixed size array"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ extern crate heapsize;
 use heapsize::HeapSizeOf;
 
 #[cfg(not(feature = "std"))]
-use alloc::Vec;
+use alloc::vec::Vec;
 
 #[macro_export]
 macro_rules! impl_elastic_array {


### PR DESCRIPTION
Rust removed re-using of structs in the alloc crate.
this is fixing this.

Tested with `nightly-2018-09-14-x86_64-unknown-linux-gnu` (without default features) and stable `rustc 1.29.0` (with default features)